### PR TITLE
Upstream initial fixes

### DIFF
--- a/certs/kubernetes.nix
+++ b/certs/kubernetes.nix
@@ -16,6 +16,7 @@ let
       # Alternative names remain, as they might be useful for debugging purposes
       getAltNames "controlplane" ++
       getAltNames "loadbalancer" ++
+      lib.singleton "10.32.0.1" ++
       [ "kubernetes" "kubernetes.default" "kubernetes.default.svc" "kubernetes.default.svc.cluster" "kubernetes.svc.cluster.local" ];
   };
 

--- a/modules/controlplane/apiserver.nix
+++ b/modules/controlplane/apiserver.nix
@@ -60,6 +60,8 @@ in
     authorizationMode = [ "RBAC" "Node" "ABAC" ];
     authorizationPolicy = corednsPolicies;
 
+    allowPrivileged = true;
+
     etcd = {
       servers = etcdServers;
       caFile = "/var/lib/secrets/kubernetes/apiserver/etcd-ca.pem";

--- a/modules/controlplane/controller-manager.nix
+++ b/modules/controlplane/controller-manager.nix
@@ -18,6 +18,11 @@ in
 
   services.kubernetes.controllerManager = {
     enable = true;
+
+    # TODO: separate from server keys
+    serviceAccountKeyFile = "/var/lib/secrets/kubernetes/apiserver/server-key.pem";
+    rootCaFile = "/var/lib/secrets/kubernetes/ca.pem";
+
     kubeconfig = {
       caFile = "/var/lib/secrets/kubernetes/ca.pem";
       certFile = "/var/lib/secrets/kubernetes/controller-manager.pem";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,6 +1,6 @@
 builtins.fetchGit {
-  name = "nixos-22.05-2022-05-31";
+  name = "nixos-22.11-2023-01-15";
   url = "https://github.com/NixOS/nixpkgs";
-  ref = "refs/heads/nixos-22.05";
-  rev = "08950a6e29cf7bddee466592eb790a417550f7f9";
+  ref = "refs/heads/nixos-22.11";
+  rev = "2f9fd351ec37f5d479556cd48be4ca340da59b8f";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,7 @@ pkgs.mkShell {
     # software for testing
     etcd
     kubectl
+    openssl
 
     # scripts
     ci-lint


### PR DESCRIPTION
Hey, thanks for the hard work putting out this proof of concept. I'm attempting to build better kubernetes infrastructure than what is offered in Nixpkgs and using this as ground-work is giving me a lot of inspiration. While I'm aiming at something more production-grade than a toy cluster I started out with this and fixed a few issues I identified while trying to deploy applications into the cluster after initial bootstrap such as the Cilium CNI.

Issues identified and fixed:

- The kubernetes.default.svc.cluster.local certificate should contain the IP address of that service (the first available IP address in the ClusterIP CIDR) since some services will try to connect to the apiserver via its IP address.
- Privileged pod creation was disabled. This being enabled can be bad for security but this can be further restricted using PodSecurity, some privileged pods can be necessary on occasion.
- ServiceAccounts created were lacking the apiserver's CA certificate. This was due to the kube-controller-manager not being supplied the certificate explicitly. According to a github issue I found, it's supposed to fallback to the CA certificate of its kubeconfig but this didn't appear to be working in practice.